### PR TITLE
Resolução da câmera (Fix #121)

### DIFF
--- a/pack-capture-gui/capture-gui/V4LInterface-aux.cpp
+++ b/pack-capture-gui/capture-gui/V4LInterface-aux.cpp
@@ -421,6 +421,12 @@ void V4LInterface::__update_cb_frame_interval() {
 }
 
 void V4LInterface::__update_all() {
+	if(init_frame){
+		bool r = vcap.set_frame_size(640, 480,
+									 V4L2_BUF_TYPE_VIDEO_CAPTURE);
+		if (!r) std::cout << "Can't set frame size!" << std::endl;
+		init_frame = false;
+	}
 	__update_cb_input();
 	__update_cb_standard();
 	__update_cb_format_desc();

--- a/pack-capture-gui/capture-gui/V4LInterface.hpp
+++ b/pack-capture-gui/capture-gui/V4LInterface.hpp
@@ -50,6 +50,7 @@ class capture::V4LInterface : public Gtk::VBox {
 		VisionGUI visionGUI;
 
 		bool warped = false;
+		bool init_frame = true;
 
 		ImageView imageView;
 		Messenger* messenger;


### PR DESCRIPTION
Iniciar resolução da câmera sempre com 640x480