### PR TITLE
Voltar valores das variáveis para versão do robô de 2017

### DIFF
--- a/cc/Strategy2/Robot2.h
+++ b/cc/Strategy2/Robot2.h
@@ -34,7 +34,7 @@ class Robot2 {
 	public:
 		Geometry::Point uvf_ref;
 
-    	const double size = 0.074;
+    	const double size = 0.08;
 		char ID = 'A';
 		unsigned int tag = 0;
 		double default_target_velocity = 0.8; // Velocidade padrão do robô

--- a/cc/vision/tag.hpp
+++ b/cc/vision/tag.hpp
@@ -5,7 +5,7 @@
 #include <iostream>
 #include <vector>
 
-#define ROBOT_RADIUS 15 // valor encontrado empiricamente (quanto menor, mais próximos os robôs podem ficar sem dar errado)
+#define ROBOT_RADIUS 17 // valor encontrado empiricamente (quanto menor, mais próximos os robôs podem ficar sem dar errado)
 
 class Tag {
 	public:


### PR DESCRIPTION
Voltando os valores da dimensão do robô para a versão de 2017 até a versão de 2019 ficar pronta.