### PR TITLE
Cria a classe VideoRecorder e faz melhorias na gravação de vídeo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,8 @@ set(SOURCE_FILES cc/main.cpp
     pack-capture-gui/capture-gui/RobotGUI.cpp
     pack-capture-gui/capture-gui/ImageArt.cpp
     pack-capture-gui/capture-gui/ImageWarp.cpp
-    cc/TestOnClick.cpp)
+    cc/TestOnClick.cpp
+    cc/VideoRecorder.cpp)
 
 #Define diretorios com .h e .hpp. Novos diretorios devem ser inclusos aqui
 include_directories(cc/

--- a/cc/CamCap.cpp
+++ b/cc/CamCap.cpp
@@ -160,6 +160,8 @@ bool CamCap::capture_and_show() {
 
 	std::map<unsigned int, Vision::RecognizedTag> tags = interface.visionGUI.vision->run(imageView);
 
+	interface.visionGUI.recorder.run(imageView);
+
 	calculate_ball_est();
 	update_positions(tags);
 

--- a/cc/VideoRecorder.cpp
+++ b/cc/VideoRecorder.cpp
@@ -7,14 +7,14 @@ void VideoRecorder::run(cv::Mat in_frame) {
 	if (is_on_air) record_to_video();
 }
 
-void VideoRecorder::save_picture(std::string in_name) {
+void VideoRecorder::save_picture(const std::string &in_name) {
 	std::string picName = "media/pictures/" + in_name + ".png";
 
 	cv::cvtColor(frame, frame, cv::COLOR_RGB2BGR);
 	cv::imwrite(picName, frame);
 }
 
-void VideoRecorder::start_new_video(std::string in_name) {
+void VideoRecorder::start_new_video(const std::string &in_name) {
 	std::string videoName = "media/videos/" + in_name + ".avi";
 
 	video.open(videoName, CV_FOURCC('M', 'J', 'P', 'G'), 30, cv::Size(width, height));

--- a/cc/VideoRecorder.cpp
+++ b/cc/VideoRecorder.cpp
@@ -1,0 +1,45 @@
+#include "VideoRecorder.hpp"
+
+using namespace rec;
+
+void VideoRecorder::run(cv::Mat in_frame) {
+	frame = in_frame.clone();
+	if (is_on_air) record_to_video();
+}
+
+void VideoRecorder::save_picture(std::string in_name) {
+	std::string picName = "media/pictures/" + in_name + ".png";
+
+	cv::cvtColor(frame, frame, cv::COLOR_RGB2BGR);
+	cv::imwrite(picName, frame);
+}
+
+void VideoRecorder::start_new_video(std::string in_name) {
+	std::string videoName = "media/videos/" + in_name + ".avi";
+
+	video.open(videoName, CV_FOURCC('M', 'J', 'P', 'G'), 30, cv::Size(width, height));
+	std::cout << "Started a new video recording." << std::endl;
+	is_on_air = true;
+}
+
+bool VideoRecorder::record_to_video() {
+	if (!video.isOpened()) return false;
+	cv::cvtColor(frame, frame, cv::COLOR_RGB2BGR);
+
+	video.write(frame);
+	return true;
+}
+
+bool VideoRecorder::finish_video() {
+	if (!video.isOpened()) return false;
+
+	std::cout << "Finished video recording." << std::endl;
+	video.release();
+	is_on_air = false;
+	return true;
+}
+
+VideoRecorder::~VideoRecorder() {
+	if (is_recording())
+		finish_video();
+}

--- a/cc/VideoRecorder.hpp
+++ b/cc/VideoRecorder.hpp
@@ -19,18 +19,17 @@ namespace rec {
 			int width, height;
 
 		public:
-			VideoRecorder(int w, int h) : width(w), height(h), is_on_air(false){};
+			VideoRecorder(int w, int h) : width(w), height(h), is_on_air(false) {};
 			~VideoRecorder();
 			bool record_to_video();
 			void run(cv::Mat frame);
 			bool finish_video();
+
 			bool is_recording() const { return is_on_air; };
 
-			void start_new_video(std::string videoName);
-			void save_picture(std::string in_name);
+			void start_new_video(const std::string &in_name);
+			void save_picture(const std::string &in_name);
 	};
 }
-
-
 
 #endif //VSSS_VIDEORECORDER_HPP

--- a/cc/VideoRecorder.hpp
+++ b/cc/VideoRecorder.hpp
@@ -1,0 +1,36 @@
+//
+// Created by daniel on 22/02/19.
+//
+
+#ifndef VSSS_VIDEORECORDER_HPP
+#define VSSS_VIDEORECORDER_HPP
+
+#include <opencv2/opencv.hpp>
+
+namespace rec {
+	class VideoRecorder {
+		private:
+			// record video flag
+			bool is_on_air;
+			cv::Mat frame;
+			// video
+			cv::VideoWriter video;
+
+			int width, height;
+
+		public:
+			VideoRecorder(int w, int h) : width(w), height(h), is_on_air(false){};
+			~VideoRecorder();
+			bool record_to_video();
+			void run(cv::Mat frame);
+			bool finish_video();
+			bool is_recording() const { return is_on_air; };
+
+			void start_new_video(std::string videoName);
+			void save_picture(std::string in_name);
+	};
+}
+
+
+
+#endif //VSSS_VIDEORECORDER_HPP

--- a/cc/VideoRecorder.hpp
+++ b/cc/VideoRecorder.hpp
@@ -1,7 +1,3 @@
-//
-// Created by daniel on 22/02/19.
-//
-
 #ifndef VSSS_VIDEORECORDER_HPP
 #define VSSS_VIDEORECORDER_HPP
 

--- a/cc/vision/vision.cpp
+++ b/cc/vision/vision.cpp
@@ -7,17 +7,10 @@ using namespace vision;
 std::map<unsigned int, Vision::RecognizedTag> Vision::run(cv::Mat raw_frame) {
 	in_frame = raw_frame.clone();
 
-	if (bOnAir) recordToVideo();
-
 	preProcessing();
 	findTags();
 	//findElements();
 	return pick_a_tag();
-}
-
-void Vision::recordVideo(const cv::Mat frame) {
-	in_frame = frame.clone();
-	if (bOnAir) recordToVideo();
 }
 
 void Vision::runGMM(std::vector<cv::Mat> thresholds, std::vector<VisionROI> *windowsList) {
@@ -575,40 +568,6 @@ void Vision::saveCameraCalibPicture(const std::string in_name, const std::string
 	cv::imwrite(picName, frame);
 }
 
-void Vision::savePicture(const std::string in_name) {
-	cv::Mat frame = in_frame.clone();
-	std::string picName = "media/pictures/" + in_name + ".png";
-
-	cv::cvtColor(frame, frame, cv::COLOR_RGB2BGR);
-	cv::imwrite(picName, frame);
-}
-
-void Vision::startNewVideo(const std::string in_name) {
-	std::string videoName = "media/videos/" + in_name + ".avi";
-
-	video.open(videoName, CV_FOURCC('M', 'J', 'P', 'G'), 30, cv::Size(width, height));
-	std::cout << "Started a new video recording." << std::endl;
-	bOnAir = true;
-}
-
-bool Vision::recordToVideo() {
-	if (!video.isOpened()) return false;
-	cv::Mat frame = in_frame.clone();
-	cv::cvtColor(frame, frame, cv::COLOR_RGB2BGR);
-
-	video.write(frame);
-	return true;
-}
-
-bool Vision::finishVideo() {
-	if (!video.isOpened()) return false;
-
-	std::cout << "Finished video recording." << std::endl;
-	video.release();
-	bOnAir = false;
-	return true;
-}
-
 cv::Mat Vision::getThreshold(const unsigned long index) {
 	cv::cvtColor(threshold_frame.at(index), threshold_frame.at(index), cv::COLOR_GRAY2RGB);
 	return threshold_frame.at(index);
@@ -672,8 +631,8 @@ void Vision::setFrameSize(const int inWidth, const int inHeight) {
 }
 
 Vision::Vision(int w, int h) : width(w), height(h), cieL{{0, 255}, {0, 255}, {0, 255}, {0, 255}},
-							   cieA{{0, 255}, {0, 255}, {0, 255}, {0, 255}}, video_rec_enable(true),
-							   cieB{{0, 255}, {0, 255}, {0, 255}, {0, 255}}, bOnAir(false),
+							   cieA{{0, 255}, {0, 255}, {0, 255}, {0, 255}},
+							   cieB{{0, 255}, {0, 255}, {0, 255}, {0, 255}},
 							   threshold_frame(MAX_COLORS), tags(MAX_COLORS), areaMin{0, 0, 0, 0},
 							   dilate{0, 0, 0, 0}, erode{0, 0, 0, 0}, blur{3, 3, 3, 3} {
 }

--- a/cc/vision/vision.hpp
+++ b/cc/vision/vision.hpp
@@ -85,12 +85,6 @@ namespace vision
 		int width;
 		int height;
 
-		// record video flag
-		bool bOnAir;
-
-		// video
-		cv::VideoWriter video;
-
 		// threads
 		boost::thread_group threshold_threads;
 
@@ -111,17 +105,8 @@ namespace vision
 
 		std::map<unsigned int, RecognizedTag> run(cv::Mat raw_frame);
 		void runGMM(std::vector<cv::Mat> thresholds, std::vector<VisionROI> *windowsList);
-		void recordVideo(cv::Mat frame);
 		double calcDistance(cv::Point p1, cv::Point p2) const;
 		void saveCameraCalibPicture(std::string in_name, std::string directory);
-		void startNewVideo(std::string videoName);
-		bool recordToVideo();
-		bool finishVideo();
-		bool isRecording() const { return bOnAir; };
-		void savePicture(std::string in_name);
-
-		//video
-		bool video_rec_enable;
 
 		//Cam calib
 		std::vector<cv::Mat> savedCamCalibFrames;

--- a/cc/vision/visionGUI.cpp
+++ b/cc/vision/visionGUI.cpp
@@ -1039,16 +1039,20 @@ bool VisionGUI::getIsCIELAB() {
 }
 
 VisionGUI::VisionGUI() :
-		CIELAB_calib_event_flag(false), Img_id(0),
+		CIELAB_calib_event_flag(false),
+		Img_id(0),
 		samplesEventFlag(false),
-		totalSamples(0), gaussiansFrame_flag(false),
-		finalFrame_flag(false), thresholdFrame_flag(false),
-		colorIndex(0), isCIELAB(true), isSplitView(false),
-		disableSplitView(false), draw_info_flag(false),
-		recorder(640, 480) {
-
-	vision = std::make_unique<Vision>(640, 480);
-	gmm = std::make_unique<GMM>(640, 480);
+		totalSamples(0),
+		gaussiansFrame_flag(false),
+		finalFrame_flag(false),
+		thresholdFrame_flag(false),
+		colorIndex(0), isCIELAB(true),
+		isSplitView(false),
+		disableSplitView(false),
+		draw_info_flag(false),
+		recorder(640, 480),
+		vision(std::make_unique<Vision>(640, 480)),
+		gmm(std::make_unique<GMM>(640, 480)) {
 
 	//__create_frm_calib_mode();
 	__create_frm_capture();

--- a/cc/vision/visionGUI.cpp
+++ b/cc/vision/visionGUI.cpp
@@ -1,6 +1,18 @@
 #include "visionGUI.hpp"
 
+
 using namespace vision;
+using namespace date;
+
+std::string date::generate_date_str() {
+	std::string date;
+	time_t tt;
+	std::chrono::system_clock::time_point now = std::chrono::system_clock::now();
+	tt = std::chrono::system_clock::to_time_t(now);
+	date.append(std::string(ctime(&tt)).substr(0, 24));
+
+	return date;
+}
 
 void VisionGUI::__create_frm_drawing_options() {
 	Gtk::Frame *frame;
@@ -544,8 +556,8 @@ void VisionGUI::__create_frm_capture() {
 }
 
 void VisionGUI::bt_record_video_pressed() {
-	if (vision->isRecording()) {
-		vision->finishVideo();
+	if (recorder.is_recording()) {
+		recorder.finish_video();
 		bt_record_video.set_label("REC");
 		en_video_name.set_text("");
 		en_video_name.set_state(Gtk::STATE_NORMAL);
@@ -555,10 +567,11 @@ void VisionGUI::bt_record_video_pressed() {
 		bt_record_video.set_label("Stop");
 		en_video_name.set_state(Gtk::STATE_INSENSITIVE);
 		if (name.empty()) {
-			vision->startNewVideo(std::to_string(vidIndex++));
-			en_video_name.set_text(std::to_string(vidIndex));
+			std::string date = generate_date_str();
+			en_video_name.set_text(date);
+			recorder.start_new_video(date);
 		} else {
-			vision->startNewVideo(name);
+			recorder.start_new_video(name);
 		}
 	}
 }
@@ -566,9 +579,10 @@ void VisionGUI::bt_record_video_pressed() {
 void VisionGUI::bt_save_picture_clicked() {
 	std::string name = en_picture_name.get_text();
 	if (name.empty()) {
-		vision->savePicture(std::to_string(picIndex++));
+		std::string date = generate_date_str();
+		recorder.save_picture(date);
 	} else {
-		vision->savePicture(name);
+		recorder.save_picture(name);
 	}
 	en_picture_name.set_text("");
 }
@@ -1026,14 +1040,15 @@ bool VisionGUI::getIsCIELAB() {
 
 VisionGUI::VisionGUI() :
 		CIELAB_calib_event_flag(false), Img_id(0),
-		vidIndex(0), picIndex(0), samplesEventFlag(false),
+		samplesEventFlag(false),
 		totalSamples(0), gaussiansFrame_flag(false),
 		finalFrame_flag(false), thresholdFrame_flag(false),
 		colorIndex(0), isCIELAB(true), isSplitView(false),
-		disableSplitView(false), draw_info_flag(false) {
+		disableSplitView(false), draw_info_flag(false),
+		recorder(640, 480) {
 
-	vision = new Vision(640, 480);
-	gmm = new GMM(640, 480);
+	vision = std::make_unique<Vision>(640, 480);
+	gmm = std::make_unique<GMM>(640, 480);
 
 	//__create_frm_calib_mode();
 	__create_frm_capture();
@@ -1041,8 +1056,4 @@ VisionGUI::VisionGUI() :
 	__create_frm_split_view();
 	__create_frm_cielab();
 	//__create_frm_gmm();
-}
-
-VisionGUI::~VisionGUI() {
-	if (vision->isRecording()) vision->finishVideo();
 }

--- a/cc/vision/visionGUI.hpp
+++ b/cc/vision/visionGUI.hpp
@@ -4,12 +4,18 @@
 #include <gtkmm.h>
 #include "vision.hpp"
 #include "gmm.hpp"
+#include "VideoRecorder.hpp"
 #include "../filechooser.hpp"
+
+namespace date {
+	std::string generate_date_str();
+}
 
 class VisionGUI : public Gtk::VBox {
 	public:
-		vision::Vision *vision;
-		GMM *gmm;
+		std::unique_ptr<vision::Vision> vision;
+		std::unique_ptr<GMM> gmm;
+		rec::VideoRecorder recorder;
 		Gtk::ToggleButton bt_LAB_calib;
 
 		unsigned long Img_id;
@@ -40,7 +46,6 @@ class VisionGUI : public Gtk::VBox {
 		Gtk::RadioButton rb_mode_GMM, rb_mode_CIELAB;
 
 		VisionGUI();
-		~VisionGUI() override;
 
 		void update_vision_hscale_values();
 
@@ -75,9 +80,6 @@ class VisionGUI : public Gtk::VBox {
 		// Frame Split View
 		Gtk::Frame fr_splitView;
 		bool isSplitView, disableSplitView;
-
-		// Frame Capture
-		int picIndex, vidIndex;
 
 		// Frame CIELAB Calibration
 		Gtk::Frame fr_CIELAB;

--- a/pack-capture-gui/capture-gui/V4LInterface-aux.cpp
+++ b/pack-capture-gui/capture-gui/V4LInterface-aux.cpp
@@ -833,8 +833,6 @@ void V4LInterface::initInterface() {
 	start_game_bt.set_size_request(50, 100);
 	start_game_bt.set_image(red_button_released);
 
-	record_video_checkbox.signal_clicked().connect(
-			sigc::mem_fun(*this, &capture::V4LInterface::event_toggle_enable_video_record));
 	start_game_bt.signal_clicked().connect(
 			sigc::mem_fun(*this, &capture::V4LInterface::event_start_game_bt_signal_clicked));
 

--- a/pack-capture-gui/capture-gui/V4LInterface-events.cpp
+++ b/pack-capture-gui/capture-gui/V4LInterface-events.cpp
@@ -442,10 +442,6 @@ void V4LInterface::__set_control(std::list<ControlHolder> *list, Gtk::Widget *wc
 	__update_control_widgets(ctrl_list_default);
 }
 
-void V4LInterface::event_toggle_enable_video_record(){
-	visionGUI.vision->video_rec_enable = !visionGUI.vision->video_rec_enable;
-}
-
 void V4LInterface::event_start_game_bt_signal_clicked() {
 	if (!start_game_flag) {
 
@@ -461,21 +457,16 @@ void V4LInterface::event_start_game_bt_signal_clicked() {
 		btn_camCalib_start.set_state(Gtk::STATE_INSENSITIVE);
 		btn_camCalib_pop.set_state(Gtk::STATE_INSENSITIVE);
 
-		std::string dateString;
-		time_t tt;
-		std::chrono::system_clock::time_point now = std::chrono::system_clock::now();
-		tt = std::chrono::system_clock::to_time_t(now);
-		dateString.append(std::string(ctime(&tt)).substr(0, 24));
-
-		if (visionGUI.vision->isRecording()) {
-			visionGUI.vision->finishVideo();
-			visionGUI.bt_record_video.set_label("REC");
+		if (!visionGUI.recorder.is_recording() && record_video_checkbox.get_active()) {
+			std::string date = date::generate_date_str();
+			visionGUI.en_video_name.set_text(date);
+			visionGUI.bt_record_video.set_active(true);
+			visionGUI.bt_record_video.set_label("Stop");
+			visionGUI.recorder.start_new_video(date);
 		}
-		visionGUI.bt_record_video.set_state(Gtk::STATE_INSENSITIVE);
+
 		visionGUI.en_video_name.set_state(Gtk::STATE_INSENSITIVE);
-		visionGUI.en_video_name.set_text(dateString);
-		if(visionGUI.vision->video_rec_enable)
-			visionGUI.vision->startNewVideo(dateString);
+
 	} else {
 		if (controlGUI.messenger.has_xbee())
 			controlGUI.test_start_bt.set_state(Gtk::STATE_NORMAL);
@@ -483,10 +474,14 @@ void V4LInterface::event_start_game_bt_signal_clicked() {
 		record_video_checkbox.set_sensitive(true);
 		btn_camCalib.set_state(Gtk::STATE_NORMAL);
 
-		if(visionGUI.vision->video_rec_enable)
-			visionGUI.vision->finishVideo();
+		if(visionGUI.recorder.is_recording()) {
+			visionGUI.recorder.finish_video();
+			visionGUI.bt_record_video.set_label("REC");
+		}
+
 
 		visionGUI.bt_record_video.set_state(Gtk::STATE_NORMAL);
+		visionGUI.bt_record_video.set_active(false);
 		visionGUI.en_video_name.set_state(Gtk::STATE_NORMAL);
 		visionGUI.en_video_name.set_text("");
 		start_game_flag = false;

--- a/pack-capture-gui/capture-gui/V4LInterface.hpp
+++ b/pack-capture-gui/capture-gui/V4LInterface.hpp
@@ -147,7 +147,6 @@ class capture::V4LInterface : public Gtk::VBox {
 		void __event_cb_frame_interval_changed();
 		void createPositionsAndButtonsFrame();
 		void event_start_game_bt_signal_clicked();
-		void event_toggle_enable_video_record();
 		void updateRobotLabels();
 		void update_ball_position(Geometry::Point ball);
 		void updateFPS(int fps);


### PR DESCRIPTION
- É possível parar uma gravação no meio do jogo;
- Ao começar o jogo, se uma gravação de vídeo está em curso, a gravação continua ao invés de parar a gravação para começar uma nova (jeito antigo).
- Pausar o jogo continua encerrando a gravação de vídeo.
- Caso o usuário não forneça um nome para a imagem ou vídeo a ser gravado, será usado a data e hora do início da gravação e não mais um número atrelado a um contador.