### PR TITLE
Adiciona a opção de seguir a bola no Test On Click

### DIFF
--- a/cc/CamCap.cpp
+++ b/cc/CamCap.cpp
@@ -277,7 +277,8 @@ CamCap::CamCap(int screenW, int screenH, bool isLowRes) : data(nullptr), width(0
 														  screenWidth(screenW), screenHeight(screenH),
 														  msg_thread(&CamCap::send_cmd_thread, this),
 														  robotGUI(robots, isLowRes),
-														  interface(&interface.controlGUI.messenger, robots, robotGUI, isLowRes),
+														  interface(&interface.controlGUI.messenger, robots,
+																	ball, robotGUI, isLowRes),
 														  strategy(attacker, defender, goalkeeper, ball, ball_est),
 														  robots{&attacker, &defender, &goalkeeper} {
 

--- a/cc/TestOnClick.cpp
+++ b/cc/TestOnClick.cpp
@@ -13,11 +13,11 @@ void TestOnClick::run() {
 	else {
 		switch (m_command) {
 			case Robot2::Command::Position:
-					m_selected_robot->go_to_and_stop(m_target);
+					m_selected_robot->go_to_and_stop(get_target());
 				break;
 			case Robot2::Command::UVF:
-				if (Geometry::distance(m_selected_robot->get_position(), m_target) > 0.08)
-					m_selected_robot->go_to_pose(m_target, m_orientation);
+				if (Geometry::distance(m_selected_robot->get_position(), get_target()) > 0.08)
+					m_selected_robot->go_to_pose(get_target(), m_orientation);
 				else
 					m_selected_robot->set_target_orientation(m_orientation);
 				break;
@@ -40,8 +40,15 @@ void TestOnClick::set_orientation(const double orientation) {
 	m_orientation = Geometry::Vector(1, Geometry::degree_to_rad(orientation));
 }
 
-TestOnClick::TestOnClick(const std::array<Robot2 *, 3> &robots) : m_is_active(false), m_robots(robots), m_command(Robot2::Command::None),
-	m_target(-1, -1), m_orientation(1, 0), m_selected_robot(nullptr){
+TestOnClick::TestOnClick(const std::array<Robot2 *, 3> &robots, const Geometry::Point &ball)
+		: m_is_active(false),
+		m_robots(robots),
+		m_ball(ball),
+		m_command(Robot2::Command::None),
+		m_target({-1, -1}),
+		m_orientation(1, 0),
+		m_selected_robot(nullptr),
+		m_is_target_ball(false) {
 }
 
 void TestOnClick::select_robot(const double x,const double y) {
@@ -59,7 +66,14 @@ void TestOnClick::select_target(const double x,const double y) {
 	if (!has_robot())
 		return;
 
-	m_target = Geometry::from_cv_point(x,y);
+	Geometry::Point target = Geometry::from_cv_point(x,y);
+
+	if (Geometry::distance(target, m_ball) < m_ball_radius) {
+		m_is_target_ball = true;
+	} else {
+		m_is_target_ball = false;
+		m_target = target;
+	}
 
 	if (m_command == Robot2::Command::Vector || m_command == Robot2::Command::Orientation)
 		m_orientation = Geometry::Vector(m_target - m_selected_robot->get_position());
@@ -67,7 +81,8 @@ void TestOnClick::select_target(const double x,const double y) {
 
 void TestOnClick::set_active(const bool is_active) {
 	if (!is_active) {
-		m_target = Geometry::Point(-1, -1);
+		m_target = {-1, -1};
+		m_is_target_ball = false;
 		if (has_robot()) {
 			m_selected_robot->stop();
 			m_selected_robot = nullptr;
@@ -79,5 +94,6 @@ void TestOnClick::set_active(const bool is_active) {
 
 void TestOnClick::set_command(const Robot2::Command command) {
 	m_command = command;
-	m_target = Geometry::Point(-1, -1);
+	m_target = {-1, -1};
+	m_is_target_ball = false;
 }

--- a/cc/TestOnClick.hpp
+++ b/cc/TestOnClick.hpp
@@ -10,18 +10,23 @@ namespace onClick {
 			bool m_is_active;
 
 			const std::array<Robot2 *, 3>& m_robots;
+			const Geometry::Point& m_ball;
 			Robot2* m_selected_robot;
+
+			const double m_ball_radius = 0.02135; // metros
+
+			bool m_is_target_ball;
 
 			Robot2::Command m_command;
 
 			Geometry::Point m_target;
 			Geometry::Vector m_orientation;
 
-			const bool is_target_valid() const { return m_target.x >= 0 || m_target.y >= 0; };
+			const bool is_target_valid() const { return  m_is_target_ball || (m_target.x >= 0 && m_target.y >= 0); };
 
 		public:
 
-			explicit TestOnClick(const std::array<Robot2 *, 3> &robots);
+			explicit TestOnClick(const std::array<Robot2 *, 3> &robots, const Geometry::Point &ball);
 
 			void run();
 
@@ -32,7 +37,7 @@ namespace onClick {
 			Robot2::Command get_command() const { return m_command; };
 			Robot2* get_selected_robot() const { return m_selected_robot; };
 			double get_orientation_value() const { return m_orientation.theta; };
-			Geometry::Point get_target() const { return m_target; };
+			Geometry::Point get_target() const { return m_is_target_ball? m_ball : m_target; };
 
 			bool is_active() const { return m_is_active; };
 			bool has_robot() const { return m_selected_robot != nullptr; };

--- a/cc/controlGUI.cpp
+++ b/cc/controlGUI.cpp
@@ -1,6 +1,8 @@
 #include "controlGUI.hpp"
 
-ControlGUI::ControlGUI(const std::array<Robot2 *, 3> &robots) : test_controller(robots) {
+ControlGUI::ControlGUI(const std::array<Robot2 *, 3> &robots, const Geometry::Point &ball)
+	: test_controller(robots, ball) {
+
 	// Adicionar o frame do Serial e sua VBOX
 	pack_start(Top_hbox, false, true, 5);
 	Top_hbox.pack_start(Serial_fm, true, true, 0);

--- a/cc/controlGUI.hpp
+++ b/cc/controlGUI.hpp
@@ -77,7 +77,7 @@ class ControlGUI : public Gtk::VBox {
 
 		void _test_start_bt_event();
 
-		explicit ControlGUI(const std::array<Robot2 *, 3> &robots);
+		explicit ControlGUI(const std::array<Robot2 *, 3> &robots, const Geometry::Point &ball);
 
 		void stop_test_on_click();
 

--- a/pack-capture-gui/capture-gui/V4LInterface-aux.cpp
+++ b/pack-capture-gui/capture-gui/V4LInterface-aux.cpp
@@ -953,15 +953,15 @@ void V4LInterface::__create_frm_cam_calib() {
 }
 
 // Constructor
-V4LInterface::V4LInterface(Messenger *messenger_ptr, const std::array<Robot2 *, 3> &robots_ref, RobotGUI &robot_gui,
-						   bool isLow)
+V4LInterface::V4LInterface(Messenger *messenger_ptr, const std::array<Robot2 *, 3> &robots_ref,
+						   const Geometry::Point &ball, RobotGUI &robot_gui, bool isLow)
 		:
 		Gtk::VBox(false, 0),
 		isLowRes(isLow),
 		robots(robots_ref),
 		robotGUI(robot_gui),
 		imageView(controlGUI.test_controller),
-		controlGUI(robots_ref) {
+		controlGUI(robots_ref, ball) {
 
 	messenger = messenger_ptr;
 	initInterface();

--- a/pack-capture-gui/capture-gui/V4LInterface.hpp
+++ b/pack-capture-gui/capture-gui/V4LInterface.hpp
@@ -84,8 +84,8 @@ class capture::V4LInterface : public Gtk::VBox {
 
 		capture::v4lcap vcap;
 
-		explicit V4LInterface(Messenger *messenger_ptr, const std::array<Robot2 *, 3> &robots_ref, RobotGUI &robot_gui,
-									  bool isLow);
+		explicit V4LInterface(Messenger *messenger_ptr, const std::array<Robot2 *, 3> &robots_ref,
+									  const Geometry::Point &ball, RobotGUI &robot_gui, bool isLow);
 		void initInterface();
 
 		Gtk::Scale HScale_offsetL;


### PR DESCRIPTION
- Selecionar a bola com o botão direito do mouse na imagem no Test On Click faz com que o alvo seja a bola (independentemente de onde ela estiver)