### PR TITLE
Adiciona a funcionalidade de mover pontos durante Warp/Adjust

### DIFF
--- a/pack-capture-gui/capture-gui/ImageArt.cpp
+++ b/pack-capture-gui/capture-gui/ImageArt.cpp
@@ -103,7 +103,24 @@ void ImageArt::draw(cv::Mat &frame, const std::vector<cv::Point> &gmm_points, co
 
 		for (unsigned short index = 0; index < adjust_mat.get_size(); index++) {
 			cv::Point point = adjust_mat.unordered_at(index);
+
+			// desenhar retầngulos
+			if (point.x <= width / 2 && point.y <= height / 2) {
+				cv::line(frame, {point.x, 0}, point, adjust_color, 1, cv::LINE_AA);
+				cv::line(frame, {0, point.y}, point, adjust_color, 1, cv::LINE_AA);
+			} else if (point.x <= width / 2 && point.y > height / 2) {
+				cv::line(frame, {point.x, height}, point, adjust_color, 1, cv::LINE_AA);
+				cv::line(frame, {0, point.y}, point, adjust_color, 1, cv::LINE_AA);
+			} else if (point.x > width / 2 && point.y <= height / 2) {
+				cv::line(frame, {point.x, 0}, point, adjust_color, 1, cv::LINE_AA);
+				cv::line(frame, {width, point.y}, point, adjust_color, 1, cv::LINE_AA);
+			} else {
+				cv::line(frame, {point.x, height}, point, adjust_color, 1, cv::LINE_AA);
+				cv::line(frame, {width, point.y}, point, adjust_color, 1, cv::LINE_AA);
+			}
+
 			cv::circle(frame, point, 2, adjust_color, thickness);
+
 			cv::putText(frame, std::to_string(index + 1), {point.x + 5, point.y - 5},
 						cv::FONT_HERSHEY_COMPLEX_SMALL, 0.7, adjust_color, 1, cv::LINE_AA);
 		}
@@ -152,7 +169,11 @@ void ImageArt::draw_targets(const Robot2 *robot, cv::Mat &frame) {
 	} // switch
 }
 
-ImageArt::ImageArt(warp::PointArray &warp, warp::PointArray &adjust, TestOnClick & test)
-	: warp_mat(warp), adjust_mat(adjust), test_on_click(test){
+ImageArt::ImageArt(warp::PointArray &warp, warp::PointArray &adjust, onClick::TestOnClick &test, int &width, int &height)
+	: warp_mat(warp),
+	adjust_mat(adjust),
+	test_on_click(test),
+	width(width),
+	height(height){
 
 }

--- a/pack-capture-gui/capture-gui/ImageArt.cpp
+++ b/pack-capture-gui/capture-gui/ImageArt.cpp
@@ -75,7 +75,7 @@ void ImageArt::draw(cv::Mat &frame, const std::vector<cv::Point> &gmm_points, co
 						font, scale, warp_color, thickness, cv::LINE_AA);
 		}
 
-		for (unsigned short index = 0; index < warp_mat.get_size(); index++) {
+		for (unsigned short index = 0; index < warp_mat.size(); index++) {
 			cv::Point point = warp_mat.unordered_at(index);
 			cv::circle(frame, point, 2, warp_color, 2);
 			cv::putText(frame, std::to_string(index + 1), {point.x + 5, point.y - 5},
@@ -101,7 +101,7 @@ void ImageArt::draw(cv::Mat &frame, const std::vector<cv::Point> &gmm_points, co
 						font, scale, adjust_color, thickness, cv::LINE_AA);
 		}
 
-		for (unsigned short index = 0; index < adjust_mat.get_size(); index++) {
+		for (unsigned short index = 0; index < adjust_mat.size(); index++) {
 			cv::Point point = adjust_mat.unordered_at(index);
 
 			// desenhar retầngulos

--- a/pack-capture-gui/capture-gui/ImageArt.hpp
+++ b/pack-capture-gui/capture-gui/ImageArt.hpp
@@ -12,11 +12,13 @@
 #include "TestOnClick.hpp"
 
 namespace art {
-
 	class ImageArt {
 		private:
 			bool is_warping = false;
 			bool is_adjusting = false;
+
+			int& width;
+			int& height;
 
 			const warp::PointArray& warp_mat;
 			const warp::PointArray& adjust_mat;
@@ -35,7 +37,7 @@ namespace art {
 			void draw_targets(const Robot2 *robot, cv::Mat &frame);
 
 		public:
-			ImageArt(warp::PointArray& warp, warp::PointArray& adjust, onClick::TestOnClick& test);
+			ImageArt(warp::PointArray &warp, warp::PointArray &adjust, onClick::TestOnClick &test, int &width, int &height);
 			void draw(cv::Mat &frame, const std::vector<cv::Point> &gmm_points, const vision::Vision::Ball &ball,
 					  const std::map<unsigned int, vision::Vision::RecognizedTag> &our_tags,
 					  const std::vector<cv::Point> &adv_tags,

--- a/pack-capture-gui/capture-gui/ImageView.cpp
+++ b/pack-capture-gui/capture-gui/ImageView.cpp
@@ -46,8 +46,16 @@ bool ImageView::on_button_press_event(GdkEventButton *event) {
 	return true;
 }
 
-ImageView::ImageView(TestOnClick &test_controller) : test_on_click(&test_controller), data(nullptr), width(0), height(0), stride(0),
-	imageArt(imageWarp.get_warp(), imageWarp.get_adjust(), test_controller){
+ImageView::ImageView(TestOnClick &test_controller) : test_on_click(&test_controller),
+													 data(nullptr),
+													 width(0),
+													 height(0),
+													 stride(0),
+													 imageArt(imageWarp.get_warp(),
+													 		  imageWarp.get_adjust(),
+															  test_controller,
+															  width,
+															  height) {
 }
 
 void ImageView::set_data(unsigned char *data, int width, int height) {

--- a/pack-capture-gui/capture-gui/ImageView.cpp
+++ b/pack-capture-gui/capture-gui/ImageView.cpp
@@ -23,16 +23,20 @@ bool ImageView::on_button_press_event(GdkEventButton *event) {
 	}
 
 	if (warp_event_flag) {
-		if (event->button == 1)
-			warp_event_flag = imageWarp.add_mat_point({static_cast<int>(event->x), static_cast<int>(event->y)});
-		if (event->button == 3)
+		if (event->button == 1) {
+			select_point(event->x, event->y);
+			if (!is_point_selected())
+				warp_event_flag = imageWarp.add_mat_point({static_cast<int>(event->x), static_cast<int>(event->y)});
+		} else if (event->button == 3)
 			imageWarp.warp_undo();
 	}
 
 	if (adjust_event_flag) {
-		if (event->button == 1)
-			adjust_event_flag = imageWarp.add_mat_point({static_cast<int>(event->x), static_cast<int>(event->y)}, true);
-		if (event->button == 3)
+		if (event->button == 1) {
+			select_point(event->x, event->y, false);
+			if (!is_point_selected())
+				adjust_event_flag = imageWarp.add_mat_point({static_cast<int>(event->x), static_cast<int>(event->y)}, true);
+		} else if (event->button == 3)
 			imageWarp.adjust_undo();
 	}
 
@@ -66,7 +70,7 @@ void ImageView::set_data(unsigned char *data, int width, int height) {
 }
 
 void ImageView::disable_image_show() {
-	data = 0;
+	data = nullptr;
 	width = 0;
 	height = 0;
 	stride = 0;
@@ -77,7 +81,7 @@ void ImageView::refresh() {
 }
 
 bool ImageView::on_draw(const Cairo::RefPtr<Cairo::Context> &cr) {
-	add_events(Gdk::BUTTON_PRESS_MASK);
+	add_events(Gdk::BUTTON_PRESS_MASK | Gdk::BUTTON_MOTION_MASK | Gdk::BUTTON_RELEASE_MASK);
 	if (!data) return false;
 
 	pb = Gdk::Pixbuf::create_from_data(data, Gdk::COLORSPACE_RGB, false, 8, width, height, stride);
@@ -106,4 +110,42 @@ bool ImageView::on_draw(const Cairo::RefPtr<Cairo::Context> &cr) {
 //    				layout->show_in_cairo_context(cr);
 
 	return true;
+}
+
+bool capture::ImageView::on_motion_notify_event(GdkEventMotion *event) {
+	if (is_point_selected()) {
+		auto x = static_cast<int>(event->x);
+		auto y = static_cast<int>(event->y);
+		if (warp_event_flag) {
+			warp::PointArray& warp_mat = imageWarp.get_warp();
+			selected_pt = warp_mat.replace(selected_pt, cv::Point(x, y));
+			return true;
+		} else if (adjust_event_flag) {
+			warp::PointArray& adjust_mat = imageWarp.get_adjust();
+			selected_pt = adjust_mat.replace(selected_pt, cv::Point(x, y));
+			return true;
+		}
+	}
+	return false;
+}
+
+bool capture::ImageView::on_button_release_event(GdkEventButton *event) {
+	if ((adjust_event_flag || warp_event_flag) && event->button == 1) {
+		selected_pt = no_point;
+		return true;
+	}
+	return false;
+}
+
+void capture::ImageView::select_point(gdouble x, gdouble y, bool is_warp) {
+	warp::PointArray &mat = is_warp ? imageWarp.get_warp() : imageWarp.get_adjust();
+
+	for (unsigned short index = 0; index < mat.size(); index++) {
+		gdouble dist = sqrt(pow(x - mat[index].x, 2) + pow(y - mat[index].y, 2));
+		if (dist < 10) { // 10 pixels
+			selected_pt = mat[index];
+			return;
+		}
+	}
+	selected_pt = no_point;
 }

--- a/pack-capture-gui/capture-gui/ImageView.cpp
+++ b/pack-capture-gui/capture-gui/ImageView.cpp
@@ -114,8 +114,8 @@ bool ImageView::on_draw(const Cairo::RefPtr<Cairo::Context> &cr) {
 
 bool capture::ImageView::on_motion_notify_event(GdkEventMotion *event) {
 	if (is_point_selected()) {
-		auto x = static_cast<int>(event->x);
-		auto y = static_cast<int>(event->y);
+		const auto x = static_cast<int>(event->x);
+		const auto y = static_cast<int>(event->y);
 		if (warp_event_flag) {
 			warp::PointArray& warp_mat = imageWarp.get_warp();
 			selected_pt = warp_mat.replace(selected_pt, cv::Point(x, y));
@@ -137,7 +137,7 @@ bool capture::ImageView::on_button_release_event(GdkEventButton *event) {
 	return false;
 }
 
-void capture::ImageView::select_point(gdouble x, gdouble y, bool is_warp) {
+void capture::ImageView::select_point(const gdouble x, const gdouble y, const bool is_warp) {
 	warp::PointArray &mat = is_warp ? imageWarp.get_warp() : imageWarp.get_adjust();
 
 	for (unsigned short index = 0; index < mat.size(); index++) {

--- a/pack-capture-gui/capture-gui/ImageView.hpp
+++ b/pack-capture-gui/capture-gui/ImageView.hpp
@@ -36,7 +36,7 @@ class capture::ImageView : public Gtk::DrawingArea {
 		bool on_motion_notify_event(GdkEventMotion* event) override;
 
 		void select_point(gdouble x, gdouble y, bool is_warp = true);
-		bool is_point_selected() { return selected_pt != no_point; };
+		bool is_point_selected() const { return selected_pt != no_point; };
 	public:
 		warp::ImageWarp imageWarp;
 		art::ImageArt imageArt;

--- a/pack-capture-gui/capture-gui/ImageView.hpp
+++ b/pack-capture-gui/capture-gui/ImageView.hpp
@@ -23,12 +23,20 @@ namespace capture {
 }
 
 class capture::ImageView : public Gtk::DrawingArea {
-
 		Glib::RefPtr<Gdk::Pixbuf> pb;
-		bool on_button_press_event(GdkEventButton *event) override;
 
 		onClick::TestOnClick* test_on_click;
 
+		// warp/adjust selected point on click
+		const cv::Point no_point = cv::Point(-1, -1);
+		cv::Point selected_pt;
+
+		bool on_button_press_event(GdkEventButton *event) override;
+		bool on_button_release_event(GdkEventButton *event) override;
+		bool on_motion_notify_event(GdkEventMotion* event) override;
+
+		void select_point(gdouble x, gdouble y, bool is_warp = true);
+		bool is_point_selected() { return selected_pt != no_point; };
 	public:
 		warp::ImageWarp imageWarp;
 		art::ImageArt imageArt;

--- a/pack-capture-gui/capture-gui/ImageWarp.cpp
+++ b/pack-capture-gui/capture-gui/ImageWarp.cpp
@@ -30,7 +30,7 @@ void PointArray::undo() {
 	}
 }
 
-cv::Point PointArray::replace(cv::Point old_pt, cv::Point new_pt) {
+cv::Point PointArray::replace(const cv::Point old_pt, const cv::Point new_pt) {
 	cv::Point* replace_pt = std::find(std::begin(mat), std::end(mat), old_pt);
 	if (replace_pt != std::end(mat)) {
 		*replace_pt = new_pt;

--- a/pack-capture-gui/capture-gui/ImageWarp.cpp
+++ b/pack-capture-gui/capture-gui/ImageWarp.cpp
@@ -28,6 +28,17 @@ void PointArray::undo() {
 	} else if (counter > 0) {
 		counter--;
 	}
+}
+
+cv::Point PointArray::replace(cv::Point old_pt, cv::Point new_pt) {
+	cv::Point* replace_pt = std::find(std::begin(mat), std::end(mat), old_pt);
+	if (replace_pt != std::end(mat)) {
+		*replace_pt = new_pt;
+		replace_pt = std::find(std::begin(unordered_mat), std::end(unordered_mat), old_pt);
+		*replace_pt = new_pt;
+		return new_pt;
+	}
+	return old_pt;
 };
 
 void ImageWarp::set_offset_R(const unsigned short offset) {

--- a/pack-capture-gui/capture-gui/ImageWarp.hpp
+++ b/pack-capture-gui/capture-gui/ImageWarp.hpp
@@ -32,8 +32,9 @@ namespace warp {
 			bool is_full() const { return counter == MAX_POINTS; };
 			bool add_point(const cv::Point &point);
 			void undo();
+			cv::Point replace(cv::Point old_pt, cv::Point new_pt);
 
-			unsigned short get_size() const { return counter; };
+			unsigned short size() const { return counter; };
 	};
 
 	class ImageWarp {


### PR DESCRIPTION
- Para mover os pontos, basta selecionar o ponto de warp/adjust clicando com o botão esquerdo do mouse em cima do ponto e mover o mouse com o botão esquerdo ainda pressionado. Para parar de mover o ponto, basta soltar o botão direito do mouse.
- Novos pontos são apenas criados se estiverem a uma distância de 10 pixels de pontos já existentes. Caso contrário, irá selecionar um ponto existente para movê-lo.