### PR TITLE
Correções no Erode e Dilate (Vision)

### DIFF
--- a/cc/vision/vision.cpp
+++ b/cc/vision/vision.cpp
@@ -40,8 +40,19 @@ void Vision::segmentAndSearch(const unsigned long color) {
 }
 
 void Vision::posProcessing(const unsigned long color) {
-	cv::Mat erodeElement = cv::getStructuringElement(cv::MORPH_RECT, cv::Size(3, 3));
-	cv::Mat dilateElement = cv::getStructuringElement(cv::MORPH_RECT, cv::Size(3, 3));
+	int  morphShape;
+	cv::Size size;
+
+	if (color == Color::Ball) {
+		morphShape = cv::MORPH_ELLIPSE;
+		size = cv::Size(15, 15);
+	} else {
+		morphShape = cv::MORPH_RECT;
+		size = cv::Size(3, 3);
+	}
+
+	cv::Mat erodeElement = cv::getStructuringElement(morphShape, size);
+	cv::Mat dilateElement = cv::getStructuringElement(morphShape, size);
 
 	if (blur[color] > 0) {
 		cv::medianBlur(threshold_frame.at(color), threshold_frame.at(color), blur[color]);

--- a/cc/vision/visionGUI.cpp
+++ b/cc/vision/visionGUI.cpp
@@ -703,7 +703,7 @@ void VisionGUI::__create_frm_cielab() {
 
 	HScale_Erode.set_digits(0);
 	HScale_Erode.set_increments(1, 1);
-	HScale_Erode.set_range(0, 50);
+	HScale_Erode.set_range(0, 10);
 	HScale_Erode.set_value_pos(Gtk::POS_TOP);
 	HScale_Erode.set_draw_value();
 	grid->attach(HScale_Erode, 1, 3, 2, 1);
@@ -714,7 +714,7 @@ void VisionGUI::__create_frm_cielab() {
 
 	HScale_Dilate.set_digits(0);
 	HScale_Dilate.set_increments(1, 1);
-	HScale_Dilate.set_range(0, 50);
+	HScale_Dilate.set_range(0, 10);
 	HScale_Dilate.set_value_pos(Gtk::POS_TOP);
 	HScale_Dilate.set_draw_value();
 	grid->attach(HScale_Dilate, 4, 3, 2, 1);


### PR DESCRIPTION
- Se estiver segmentando a bola, usa morph shape = cv::MORTH_ELLIPSE ao invés de cv::MORPH_RECT.
- ajusta o range das barras de erode e dilate para entre 0 e 10.