### PR TITLE
Test On Click: Ajusta orientação/alvo ao arrastar com right click.

### DIFF
--- a/cc/Strategy2/Robot2.cpp
+++ b/cc/Strategy2/Robot2.cpp
@@ -34,6 +34,7 @@ void Robot2::go_in_direction(Geometry::Vector vector, double velocity) {
 void Robot2::set_target_orientation(Geometry::Vector orientation) {
 	command = Command::Orientation;
 	target.orientation = orientation.theta;
+	target.velocity = default_target_velocity;
 }
 
 void Robot2::spin(double angular_velocity) {

--- a/cc/TestOnClick.cpp
+++ b/cc/TestOnClick.cpp
@@ -31,8 +31,6 @@ void TestOnClick::run() {
 	} else {
 		m_selected_robot->stop();
 	}
-
-	printf("%d/n", m_selected_robot->get_command());
 }
 
 void TestOnClick::set_orientation(const double orientation) {

--- a/cc/TestOnClick.cpp
+++ b/cc/TestOnClick.cpp
@@ -8,25 +8,31 @@ void TestOnClick::run() {
 	if (!m_is_active || !has_robot() || !m_is_ready)
 		return;
 
-	switch (m_command) {
-		case Robot2::Command::Position:
-			m_selected_robot->go_to_and_stop(get_target());
-			break;
-		case Robot2::Command::UVF:
-			if (Geometry::distance(m_selected_robot->get_position(), get_target()) > 0.08)
-				m_selected_robot->go_to_pose(get_target(), m_orientation);
-			else
+	if (is_target_valid()) {
+		switch (m_command) {
+			case Robot2::Command::Position:
+				m_selected_robot->go_to_and_stop(get_target());
+				break;
+			case Robot2::Command::UVF:
+				if (Geometry::distance(m_selected_robot->get_position(), get_target()) > 0.08)
+					m_selected_robot->go_to_pose(get_target(), m_orientation);
+				else
+					m_selected_robot->set_target_orientation(m_orientation);
+				break;
+			case Robot2::Command::Orientation:
 				m_selected_robot->set_target_orientation(m_orientation);
-			break;
-		case Robot2::Command::Orientation:
-			m_selected_robot->set_target_orientation(m_orientation);
-			break;
-		case Robot2::Command::Vector:
-			m_selected_robot->go_in_direction(m_orientation);
-			break;
-		default:
-			m_selected_robot->stop();
+				break;
+			case Robot2::Command::Vector:
+				m_selected_robot->go_in_direction(m_orientation);
+				break;
+			default:
+				m_selected_robot->stop();
+		}
+	} else {
+		m_selected_robot->stop();
 	}
+
+	printf("%d/n", m_selected_robot->get_command());
 }
 
 void TestOnClick::set_orientation(const double orientation) {
@@ -64,7 +70,7 @@ void TestOnClick::select_robot(const double x,const double y) {
 	for (auto &robot : m_robots) {
 		if (Geometry::distance(robot->get_position(), Geometry::from_cv_point(x,y)) < robot->SIZE/2 ) {
 			m_selected_robot = robot;
-			m_selected_robot->stop();
+			m_target = {-1, -1};
 			return;
 		}
 	}
@@ -108,7 +114,6 @@ void TestOnClick::set_command(const Robot2::Command command) {
 	m_is_target_ball = false;
 	if (has_robot())
 		m_selected_robot->stop();
-	m_is_ready = false;
 }
 
 void TestOnClick::set_ready(bool is_rdy) {

--- a/cc/TestOnClick.cpp
+++ b/cc/TestOnClick.cpp
@@ -41,7 +41,11 @@ void TestOnClick::set_orientation(const double x, const double y) {
 		return;
 
 	Geometry::Point pt = Geometry::from_cv_point(x,y);
-	m_orientation = Geometry::Vector(pt - m_selected_robot->get_position());
+	if (m_command == Robot2::Command::UVF)
+		m_orientation = Geometry::Vector(pt - m_target);
+	else
+		m_orientation = Geometry::Vector(pt - m_selected_robot->get_position());
+
 }
 
 TestOnClick::TestOnClick(const std::array<Robot2 *, 3> &robots, const Geometry::Point &ball)

--- a/cc/TestOnClick.hpp
+++ b/cc/TestOnClick.hpp
@@ -21,8 +21,7 @@ namespace onClick {
 			Geometry::Vector m_orientation;
 
 			bool m_is_target_ball;
-
-			bool is_target_valid() const { return  m_is_target_ball || (m_target.x >= 0 && m_target.y >= 0); };
+			bool m_is_ready;
 
 		public:
 
@@ -30,9 +29,12 @@ namespace onClick {
 
 			void run();
 
+			void set_ready(bool is_rdy = true);
+
 			void set_active(bool is_active = true);
 			void set_command(Robot2::Command command);
 			void set_orientation(double orientation);
+			void set_orientation(double x, double y);
 
 			Robot2::Command get_command() const { return m_command; };
 			Robot2* get_selected_robot() const { return m_selected_robot; };

--- a/cc/TestOnClick.hpp
+++ b/cc/TestOnClick.hpp
@@ -43,6 +43,7 @@ namespace onClick {
 
 			bool is_active() const { return m_is_active; };
 			bool has_robot() const { return m_selected_robot != nullptr; };
+			bool is_target_valid() const { return m_target.x >= 0 && m_target.y >= 0; }
 
 			void select_robot(double x, double y);
 			void select_target(double x, double y);

--- a/cc/controlGUI.cpp
+++ b/cc/controlGUI.cpp
@@ -488,7 +488,6 @@ void ControlGUI::adjust_widgets_state(bool is_connected) {
 
 		//Test On Click Frame
 		test_start_bt.set_state(Gtk::STATE_NORMAL);
-		test_command_cb.set_state(Gtk::STATE_NORMAL);
 		test_angle_scale.set_state(Gtk::STATE_NORMAL);
 		test_set_bt.set_state(Gtk::STATE_NORMAL);
 

--- a/pack-capture-gui/capture-gui/ImageArt.cpp
+++ b/pack-capture-gui/capture-gui/ImageArt.cpp
@@ -131,14 +131,25 @@ void ImageArt::draw_targets(const Robot2 *robot, cv::Mat &frame) {
 	if (robot == nullptr)
 		return;
 
-	cv::Scalar color = test_on_click.is_active()? test_color : strategy_color;
-	double angle = test_on_click.is_active()? test_on_click.get_orientation_value() : robot->get_target().orientation;
-	cv::Point target = test_on_click.is_active()? test_on_click.get_target().to_cv_point() : robot->get_target().position.to_cv_point();
+	cv::Scalar color;
+	double angle;
+	cv::Point target;
 	cv::Point position = robot->get_position().to_cv_point();
+	bool is_test_on_click = test_on_click.is_active();
 
-	switch (robot->get_command()) {
+	if (is_test_on_click) {
+		color = test_color;
+		angle = test_on_click.get_orientation_value();
+		target = test_on_click.get_target().to_cv_point();
+	} else {
+		color = strategy_color;
+		angle = robot->get_target().orientation;
+		robot->get_target().position.to_cv_point();
+	}
+
+	switch (is_test_on_click? test_on_click.get_command() : robot->get_command()) {
 		case Robot2::Command::Vector:
-			BOOST_FALLTHROUGH;
+			[[fallthrough]];
 		case Robot2::Command::Orientation: {
 			auto x2 = static_cast<int>(position.x + 16 * cos(angle));
 			auto y2 = static_cast<int>(position.y - 16 * sin(angle));

--- a/pack-capture-gui/capture-gui/ImageView.hpp
+++ b/pack-capture-gui/capture-gui/ImageView.hpp
@@ -31,6 +31,8 @@ class capture::ImageView : public Gtk::DrawingArea {
 		const cv::Point no_point = cv::Point(-1, -1);
 		cv::Point selected_pt;
 
+		bool has_right_click;
+
 		bool on_button_press_event(GdkEventButton *event) override;
 		bool on_button_release_event(GdkEventButton *event) override;
 		bool on_motion_notify_event(GdkEventMotion* event) override;


### PR DESCRIPTION
- O alvo passa a ser definido apenas quando soltar o botão direito do mouse;
- Quando o botão direito do mouse é pressionado, o robô para e espera que o alvo seja definido quando soltar o botão
- Arrastar o mouse com o botão direito pressionado atualiza o alvo nos comandos de Position e Vector, já nos comandos de Orientation e UVF, a orientação que é ajustada ao fazer isso.