### PR TITLE
Retira casos onde quickload eram chamados indevidamente

### DIFF
--- a/cc/CamCap.cpp
+++ b/cc/CamCap.cpp
@@ -45,6 +45,9 @@ bool CamCap::start_signal(bool b) {
 
 		interface.imageView.set_size_request(width, height);
 		con = Glib::signal_idle().connect(sigc::mem_fun(*this, &CamCap::capture_and_show));
+
+		interface.__event_bt_quick_load_clicked();
+		interface.visionGUI.quickLoadGMM();
 	} else {
 		cout << "Stop Button Clicked!" << endl;
 		con.disconnect();
@@ -52,9 +55,6 @@ bool CamCap::start_signal(bool b) {
 		// Travar os botões de edit
 		robotGUI.enable_main_buttons(false);
 	}
-
-	interface.__event_bt_quick_load_clicked();
-	interface.visionGUI.quickLoadGMM();
 
 	return true;
 } // start_signal

--- a/pack-capture-gui/capture-gui/V4LInterface-events.cpp
+++ b/pack-capture-gui/capture-gui/V4LInterface-events.cpp
@@ -324,8 +324,6 @@ void V4LInterface::__event_cb_device_changed() {
 
 	__make_control_list_default();
 
-	__event_bt_quick_load_clicked();
-
 	__make_control_table(ctrl_list_default, "Cam Configs");
 
 	__update_control_widgets(ctrl_list_default);


### PR DESCRIPTION
Parar a câmera e mudar de câmera não devem chamar quickload