### PR TITLE
Novos valores inicias de Amin

### DIFF
--- a/cc/vision/vision.cpp
+++ b/cc/vision/vision.cpp
@@ -653,7 +653,7 @@ Vision::Vision(int w, int h)
 		dilate{0, 0, 0, 0},
 		erode{0, 0, 0, 0},
 		blur{3, 3, 3, 3},
-		areaMin{0, 0, 0, 0} {
+		areaMin{50, 20, 30, 30} {
 }
 
 Vision::~Vision() = default;


### PR DESCRIPTION
Os valores são aproximadamente 25% da quantidade de pixels de cada tag, com exceção da cor do time adversário, que foi considerado um Amin menor, já que as outras equipes podem ter tags menores.