### PR TITLE
feat: improve defender positioning

### DIFF
--- a/cc/Strategy2/Field.h
+++ b/cc/Strategy2/Field.h
@@ -133,8 +133,8 @@ namespace field {
 
 	namespace defender {
 		namespace back {
-			const Geometry::Point upper_limit({goal_width+area_width+0.13, field_height/2 + area_height/2});
-			const Geometry::Point lower_limit({goal_width+area_width+0.13, field_height/2 - area_height/2});
+			const Geometry::Point upper_limit({goal_width+area_width+0.09, field_height/2 + goal_height/2});
+			const Geometry::Point lower_limit({goal_width+area_width+0.09, field_height/2 - goal_height/2});
 			const Geometry::Line line(lower_limit, upper_limit);
 		}
 		namespace front {

--- a/cc/Strategy3/DefenderStrategy.cpp
+++ b/cc/Strategy3/DefenderStrategy.cpp
@@ -9,8 +9,11 @@ void DefenderStrategy::run_strategy(const Ball &ball, const Point attacker) {
     if (is_ball_behind(our::area::front::center + Vector{0.05, 0}, ball) ||
         (is_ball_behind(our::area::front::center + Vector{0.3, 0}, ball) && distance(attacker, ball.position) < 0.1)
     ) {
-//      Sai do caminho
-        robot->go_to_and_stop({defender::back::upper_limit.x, field_height - ball.position.y});
+		// Sai do caminho e se prepara pra substituir o goleiro
+		if (ball.position.y > field_height/2)
+			wait_at_target(defender::back::lower_limit, ball.position);
+		else
+			wait_at_target(defender::back::upper_limit, ball.position);
     } else if (is_ball_est_ahead(df_limit, ball, -0.08) && !at_location(robot->get_position(), Location::AnyGoal)) {
 		// Bola na na área adversária
 		if (at_location(attacker, Location::UpperField))

--- a/cc/Strategy3/DefenderStrategy.cpp
+++ b/cc/Strategy3/DefenderStrategy.cpp
@@ -10,17 +10,14 @@ void DefenderStrategy::run_strategy(const Ball &ball, const Point attacker) {
         (is_ball_behind(our::area::front::center + Vector{0.3, 0}, ball) && distance(attacker, ball.position) < 0.1)
     ) {
 		// Sai do caminho e se prepara pra substituir o goleiro
-		if (ball.position.y > field_height/2)
+		if (at_location(ball.position, Location::UpperField))
 			wait_at_target(defender::back::lower_limit, ball.position);
 		else
 			wait_at_target(defender::back::upper_limit, ball.position);
     } else if (is_ball_est_ahead(df_limit, ball, -0.08) && !at_location(robot->get_position(), Location::AnyGoal)) {
 		// Bola na na área adversária
-		if (at_location(attacker, Location::UpperField))
-			wait_at_target(defender::front::lower::wait_point, ball.position);
-		else
-			wait_at_target(defender::front::upper::wait_point, ball.position);
-
+		double pos_y = std::clamp(ball.position.y, defender::front::lower::wait_point.y, defender::front::upper::wait_point.y);
+		wait_at_target({attacker.x - robot->SIZE*5, pos_y}, ball.position);
 	} else if (at_location(robot->get_position(), Location::AnyGoal)) {
 		exit_goal();
 	} else {

--- a/cc/Strategy3/Strategy3.cpp
+++ b/cc/Strategy3/Strategy3.cpp
@@ -222,9 +222,9 @@ void Strategy3::run_strategy(std::vector<Robot3> &team, std::vector<Geometry::Po
 // 		if (at_location(defender->get_position(), Location::OurBox)) {
 // 			defender->go_in_direction({0, 0.8});
 // 		}
-		if (at_location(defender->target.pose.position, Location::OurBox)) {
-			defender->stop();
-		}
+		// if (at_location(defender->target.pose.position, Location::OurBox)) {
+		// 	defender->stop();
+		// }
 	}
 
 	if (goalkeeper.has_robot()) goalkeeper.run_strategy(ball);


### PR DESCRIPTION
Melhora o posicionamento do defensor considerando situações de sobra de bola e preparação para substituição.

![defender attack](https://user-images.githubusercontent.com/1060058/160246324-1c607fcb-d0ba-4393-b09d-e63666070cc3.png)

No ataque (robô amarelo 1), o defensor se posiciona na sobra da dividida do atacante com o defensor adversário, acompanhando a bola em y (considerando limites para não ficar muito na lateral do campo) e uma distância segura do atacante (5 robôs de distância).

Na defesa (robô azul 1), o defensor se posiciona para substituir o goleiro em caso de troca numa posição que não atrapalhe o goleiro caso o mesmo gire para tirar a bola. Pelos testes, essa posição também é efetiva para defender cruzamentos.