### PR TITLE
fix: update attacker spin direction on defense

### DIFF
--- a/cc/Strategy2/Field.h
+++ b/cc/Strategy2/Field.h
@@ -21,7 +21,7 @@ namespace field {
 	const double corner_height = 0.3; //distancia entre a lateral do campo e a area do gol
 	const double free_ball_dist = 0.2; // distância de cobrança de falta entre bola e robô
 	const double free_ball_height = 0.25; // distância entre a lateral do campo em y e o ponto de falta
-	const double gk_line_x = 0.17;
+	const double gk_line_x = 0.16;
 	// -----------------------------------------------------------------------------------------------------------------
 
 	// Enumera todas as localizações do campo de interesse

--- a/cc/Strategy3/AttackerStrategy.cpp
+++ b/cc/Strategy3/AttackerStrategy.cpp
@@ -97,7 +97,10 @@ void AttackerStrategy::crossing(const Geometry::Point &ball){
 void AttackerStrategy::protect_goal(const Geometry::Point &ball) {
 	if (distance(robot->get_position(), ball) < robot->BALL_OFFSET) {
 		 // Se a bola chegar perto, gira para jogar a bola longe
-		robot->spin_kick_to_target(ball, their::goal::front::center);
+		if (at_location(ball, Location::UpperField))
+			robot->spin_kick_to_target(ball, {gk_line_x, field_height});
+		else
+			robot->spin_kick_to_target(ball, {gk_line_x, 0});
 	} else if (at_location(ball, Location::UpperField)) {
 		// bloquear area (cima)
 		robot->go_to_and_stop(our::corner::upper::attacker::point);
@@ -114,13 +117,12 @@ void AttackerStrategy::charged_shot(const Geometry::Point &ball) {
 void AttackerStrategy::side_spin_shot(Point ball){
 	double distance_to_ball = distance(robot->get_position(), ball);
 
-	if(robot->get_position().x < ball.x-0.01 && (distance_to_ball > 0.07) ){
+	if(robot->get_position().x < ball.x-0.01 && distance_to_ball > robot->BALL_OFFSET) {
 		//para evitar o robo ficar dançando quando estiver na lateral correndo atrás da bola
 		robot->go_to(ball);
-	}else
-	if (distance_to_ball <= 0.07 && robot->get_position().x < ball.x){
+	} else if (distance_to_ball <= robot->BALL_OFFSET && robot->get_position().x < ball.x) {
 		robot->spin_kick_to_target(ball, their::goal::front::center);
-	}else{
+	} else {
 		if(ball.y > their::goal::front::center.y){
 			Vector ball_to_side = {1,  degree_to_rad(45)};
 			robot->go_to_pose(ball, ball_to_side);


### PR DESCRIPTION
Conserta direção do spin do atacante quando está defendendo nos cantos do campo.

Existem situações em que o ângulo do objetivo pode fazer com que o robô gire levando a bola para dentro do próprio gol, como é o que acontece nesse caso: https://youtu.be/Gr7_fb9yraI?t=1753. Esse PR faz com que o atacante leve em consideração a posição da bola em relação ao gol para evitar isso.